### PR TITLE
select_query の $where/$opt の処理を切り出し

### DIFF
--- a/lib/SQL/Maker.pm
+++ b/lib/SQL/Maker.pm
@@ -196,16 +196,20 @@ sub select_query {
         }
     }
 
+    $self->_process_where($stmt, $where);
+    $self->_process_option($stmt, $opt);
+
+    return $stmt;
+}
+
+sub _process_where {
+    my ($self, $stmt, $where) = @_;
     if ( $where ) {
         my @w = ref $where eq 'ARRAY' ? @$where : %$where;
         while (my ($col, $val) = splice @w, 0, 2) {
             $stmt->add_where($col => $val);
         }
     }
-
-    $self->_process_option($stmt, $opt);
-
-    return $stmt;
 }
 
 sub _process_option {


### PR DESCRIPTION
Tengの拡張をする際に、new_select からSQLを作りたい場合があるのですが、その際に、$where/$optの処理をSQL::Makerに投げられると、嬉しいんですが。

例えば、以下のような感じです(join部分のコードはいい加減ですが例です)。
https://gist.github.com/1070298
