### PR TITLE
appropriate handling on scalar reference in SQL::Maker#select

### DIFF
--- a/lib/SQL/Maker.pm
+++ b/lib/SQL/Maker.pm
@@ -217,7 +217,7 @@ sub select_query {
 
     my $stmt = $self->new_select;
     for my $field (@$fields) {
-        $stmt->add_select(ref $field ? @$field : $field);
+        $stmt->add_select(ref $field eq 'ARRAY' ? @$field : $field);
     }
 
     if ( defined $table ) {
@@ -397,8 +397,9 @@ Table name for B<FROM> clause in scalar or arrayref. You can specify the instanc
 
 This is a list for retrieving fields from database.
 
-Each element of the C<@field> is a String of the column name normally. If you want to specify alias of the field,
-you can use ArrayRef containing the pair of column and alias name (eg. C<< ['foo.id' => 'foo_id'] >>).
+Each element of the C<@field> is a scalar or a scalar ref of the column name normally.
+If you want to specify alias of the field, you can use ArrayRef containing the pair of column
+and alias name (eg. C<< ['foo.id' => 'foo_id'] >>).
 
 =item \%where
 

--- a/lib/SQL/Maker/Select.pm
+++ b/lib/SQL/Maker/Select.pm
@@ -4,7 +4,6 @@ use warnings;
 use utf8;
 use SQL::Maker::Condition;
 use SQL::Maker::Util;
-use SQL::Maker::Condition;
 use Class::Accessor::Lite (
     new => 0,
     wo => [qw/distinct for_update/],

--- a/t/01_select.t
+++ b/t/01_select.t
@@ -18,6 +18,12 @@ subtest 'driver: sqlite' => sub {
         is join(',', @binds), '';
     };
 
+    subtest 'scalar ref columns and tables' => sub {
+        my ($sql, @binds) = $builder->select( 'foo', [ \'bar', \'baz' ] );
+        is $sql, qq{SELECT bar, baz\nFROM "foo"};
+        is join(',', @binds), '';
+    };
+
     subtest 'columns with alias column and tables' => sub {
         my ($sql, @binds) = $builder->select( 'foo', [ 'foo', [bar => 'barbar'] ] );
         is $sql, qq{SELECT "foo", "bar" AS "barbar"\nFROM "foo"};
@@ -169,6 +175,12 @@ subtest 'driver: mysql' => sub {
     subtest 'columns with alias column and tables' => sub {
         my ($sql, @binds) = $builder->select( 'foo', [ 'foo', [bar => 'barbar'] ] );
         is $sql, qq{SELECT `foo`, `bar` AS `barbar`\nFROM `foo`};
+        is join(',', @binds), '';
+    };
+
+    subtest 'scalar ref columns and tables' => sub {
+        my ($sql, @binds) = $builder->select( 'foo', [ \'bar', \'baz' ] );
+        is $sql, qq{SELECT bar, baz\nFROM `foo`};
         is join(',', @binds), '';
     };
 


### PR DESCRIPTION
An element in $field argument of SQL::Maker#select can be a scalar reference
originally along with a scalar. Sorry, I missed it.

I fixed code, document and test cases.
