### PR TITLE
Driver arg for new() support DBI handle

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2013 by Tokuhiro Matsuno E<lt>tokuhirom AAJKLFJEF@ GMAIL COME<gt>.
+This software is copyrighted (c) 2013 by Tokuhiro Matsuno E<lt>tokuhirom AAJKLFJEF@ GMAIL COME<gt>, and copyrighted (c) 2004 by David Baird.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2013 by Tokuhiro Matsuno E<lt>tokuhirom AAJKLFJEF@ GMAIL COME<gt>.
+This software is copyrighted (c) 2013 by Tokuhiro Matsuno E<lt>tokuhirom AAJKLFJEF@ GMAIL COME<gt>, and copyrighted (c) 2004 by David Baird.
 
 This is free software, licensed under:
 

--- a/META.json
+++ b/META.json
@@ -54,7 +54,8 @@
          "requires" : {
             "Test::More" : "0.98",
             "Test::Requires" : "0",
-            "Tie::IxHash" : "0"
+            "Tie::IxHash" : "0",
+            "DBD::SQLite" : "0"
          }
       }
    },

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ SQL::Maker is yet another SQL builder class. It is based on [DBIx::Skinny](http:
 
     Attributes are following:
 
-    - driver: Str
+    - driver: Str or DBI handle
 
-        Driver name is required. The driver type is needed to create SQL string.
+        Driver name or DBI handle is required. The driver type is needed to create SQL string.
 
     - quote\_char: Str
 
@@ -255,6 +255,8 @@ Whole code was taken from [DBIx::Skinny](http://search.cpan.org/perldoc?DBIx::Sk
 # LICENSE
 
 Copyright (C) Tokuhiro Matsuno
+
+Copyright (C) 2004 David Baird (for dbh driver handling)
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.

--- a/t/01_dbh.t
+++ b/t/01_dbh.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+use SQL::Maker;
+use Test::Requires qw(
+    Tie::IxHash
+    DBI
+    DBD::SQLite
+);
+
+sub ordered_hashref {
+    tie my %params, Tie::IxHash::, @_;
+    return \%params;
+}
+
+subtest 'new with dbh of SQLite as driver' => sub {
+    subtest 'driver: sqlite' => sub {
+        my $dbh = DBI->connect("dbi:SQLite:dbname=:memory:", "", "");
+        my $builder = SQL::Maker->new(driver => $dbh);
+
+        do {
+            my $stmt = $builder->select_query('foo' => ['foo', 'bar'], ordered_hashref(bar => 'baz', john => 'man'), {order_by => 'yo'});
+            is $stmt->as_sql, qq{SELECT "foo", "bar"\nFROM "foo"\nWHERE ("bar" = ?) AND ("john" = ?)\nORDER BY yo};
+            is join(',', $stmt->bind), 'baz,man';
+        };
+    };
+};
+
+done_testing;
+


### PR DESCRIPTION
This patch makes `SQL::Maker#new()` able to accept DBI handle as `driver` arg.
This feature is available on SQL::Abstract::Limit by DAVEBAIRD, and some logic (not full code) are bollowed from the module.
