### PR TITLE
micro optimization

### DIFF
--- a/lib/SQL/Maker/Condition.pm
+++ b/lib/SQL/Maker/Condition.pm
@@ -119,7 +119,7 @@ sub _make_term_by_arrayref {
         }
     } else {
         # make_term(foo => +{ 'IN', [1,2,3] }) => foo IN (1,2,3)
-        my $term = $self->_quote($col) . " $op (" . join( ', ', ('?') x scalar @$v ) . ')';
+        my $term = $self->_quote($col) . " $op (" . '?, ' x (scalar @$v - 1) . '?)';
         return ($term, $v);
     }
 }


### PR DESCRIPTION
I usually use 50-1000 id list for the 'WHERE foo IN' clause.
The function `join` seems slower than `x` operator for making a place holders string from an array.
This is benchmark. https://gist.github.com/bayashi/6c243af7377820909f36
I'm sure that the patch is slightly unreadable, however, it is enough fast.