### PR TITLE
Fix the issue that select limitation does not work on Oracle

### DIFF
--- a/lib/SQL/Maker/Select/Oracle.pm
+++ b/lib/SQL/Maker/Select/Oracle.pm
@@ -4,7 +4,7 @@ use warnings;
 use parent qw(SQL::Maker::Select);
 
 ## Oracle doesn't have the LIMIT clause.
-sub as_limit {
+sub as_sql_limit {
     return '';
 }
 

--- a/t/select/oracle/01_oracle.t
+++ b/t/select/oracle/01_oracle.t
@@ -9,7 +9,7 @@ my $sel = SQL::Maker::Select::Oracle->new( new_line => q{ } )
                                       ->limit(10)
                                       ->offset(20);
 
-is $sel->as_sql, 'SELECT * FROM ( SELECT foo, ROW_NUMBER() OVER (ORDER BY 1) R FROM user LIMIT 10 OFFSET 20 ) WHERE  R BETWEEN 20 + 1 AND 10 + 20';
+is $sel->as_sql, 'SELECT * FROM ( SELECT foo, ROW_NUMBER() OVER (ORDER BY 1) R FROM user ) WHERE  R BETWEEN 20 + 1 AND 10 + 20';
 
 done_testing;
 


### PR DESCRIPTION
Oracle does not implement LIMIT clause.
I checked Oracle 10g