### PR TITLE
Cloned object make different SQL from the original.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,4 +12,5 @@ on test => sub {
     requires 'Test::Requires';
     suggests 'DateTime';
     requires 'Tie::IxHash';
+    requires 'Clone';
 };

--- a/lib/SQL/Maker/Select.pm
+++ b/lib/SQL/Maker/Select.pm
@@ -74,10 +74,11 @@ sub bind {
 sub add_select {
     my ($self, $term, $col) = @_;
 
-    $col ||= $term;
     push @{ $self->{select} }, $term;
-    $self->{select_map}->{$term} = $col;
-    $self->{select_map_reverse}->{$col} = $term;
+    if ($col) {
+        $col ||= $term;
+        $self->{select_map_reverse}->{$col} = $term;
+    }
     return $self;
 }
 
@@ -150,6 +151,7 @@ sub as_sql {
     my $new_line = $self->new_line;
     
     if (@{ $self->{select} }) {
+        $self->{select_map} = { reverse %{$self->{select_map_reverse}} };
         $sql .= $self->{prefix};
         $sql .= 'DISTINCT ' if $self->{distinct};
         $sql .= join(', ',  map {
@@ -345,7 +347,6 @@ sub _add_index_hint {
     }
     return $quoted;
 }
-
 
 1;
 __END__

--- a/t/select/03_clone.t
+++ b/t/select/03_clone.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More;
+use Clone qw/clone/;
+
+use SQL::Maker;
+
+my $maker = SQL::Maker->new(driver => 'mysql');
+my $select = $maker->select_query('test', [
+   ['a'  => 'b'],
+   'c',
+   \'d',
+   [\'count(*)' => 'cnt'],
+   [\'sum(price)' => 'sum_price'],
+]);
+
+my $cloned = clone($select);
+
+my $sql = $select->as_sql();
+my $_sql = $sql;
+$_sql =~ s{\n}{ }g;
+is $cloned->as_sql(), $sql, "cloned object returns same sql: " . $_sql;
+
+done_testing;


### PR DESCRIPTION
About SQL::Maker::select_query,
If it has scalar reference in select, SQL from cloned object is not same SQL with the one from an original object.

It causes that scalar reference's address is used as key of `select_map`.
So, in this fix, creating select_map from select_map_reverse in `as_sql`.
And if single scalar reference is given as `$term` in select, dereference it and set it to $col before `$col ||= $term`.