### PR TITLE
SQL::Maker::Condition IN clause accepts instance of SQL::Maker::Select for a subquery

### DIFF
--- a/t/condition/02_make_term.t
+++ b/t/condition/02_make_term.t
@@ -3,6 +3,7 @@ use warnings;
 use Test::More;
 use SQL::Maker::SQLType qw/sql_type/;
 use SQL::Maker::Condition;
+use SQL::Maker::Select;
 use SQL::QueryMaker;
 use DBI qw/:sql_types/;
 
@@ -41,6 +42,7 @@ sub test {
         my $sql = $cond->as_sql;
         $sql =~ s/^\(//;
         $sql =~ s/\)$//;
+        $sql =~ s/\n/ /g;
         is $sql, $expected_term;
         is_deeply [$cond->bind], $expected_bind;
     };


### PR DESCRIPTION
This allows passing SQL::Maker::Select objects into `IN` clause as subqueries