### PR TITLE
fix pod for add_order_by args to be hash instead of hashref

### DIFF
--- a/lib/SQL/Maker/Select.pm
+++ b/lib/SQL/Maker/Select.pm
@@ -533,7 +533,7 @@ $condition should be instance of L<SQL::Maker::Condition>.
 
 =item C<< $stmt->add_order_by('foo'); >>
 
-=item C<< $stmt->add_order_by({'foo' => 'DESC'}); >>
+=item C<< $stmt->add_order_by('foo' => 'DESC'); >>
 
 Add a new ORDER BY clause.
 


### PR DESCRIPTION
## got

Pod says that `add_order_by` takes string or hashref as arguments.

```
$stmt->add_order_by('foo');
$stmt->add_order_by({'foo' => 'DESC'});
```

## expected

`add_order_by` takes string or hash (or scalar ref). ref: https://github.com/tokuhirom/SQL-Maker/blob/0a5b7183dda8ec9d1865392f3b335e27573f37e4/t/select/01_statement.t#L370-L418

## what I did

I fixed pod for `add_order_by` arguments to be hash instead of hashref.
